### PR TITLE
Update default prompt for computer use LLM

### DIFF
--- a/computer-use-demo/computer_use_demo/loop.py
+++ b/computer-use-demo/computer_use_demo/loop.py
@@ -56,8 +56,8 @@ PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
 SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>
 * You are utilising an Ubuntu virtual machine using {platform.machine()} architecture with internet access.
 * You can feel free to install Ubuntu applications with your bash tool. Use curl instead of wget.
-* To open firefox, please just click on the firefox icon.  Note, firefox-esr is what is installed on your system.
-* Using bash tool you can start GUI applications, but you need to set export DISPLAY=:1 and use a subshell. For example "(DISPLAY=:1 xterm &)". GUI apps run with bash tool will appear within your desktop environment, but they may take some time to appear. Take a screenshot to confirm it did.
+* To open Firefox, please just click on the Firefox icon.
+* Using bash tool you can start GUI applications, but you need to set export DISPLAY=:1 and use a subshell. For example "(DISPLAY=:1 gnome-terminal &)". GUI apps run with bash tool will appear within your desktop environment, but they may take some time to appear. Take a screenshot to confirm it did.
 * When using your bash tool with commands that are expected to output very large quantities of text, redirect into a tmp file and use str_replace_editor or `grep -n -B <lines before> -A <lines after> <query> <filename>` to confirm output.
 * When viewing a page it can be helpful to zoom out so that you can see everything on the page.  Either that, or make sure you scroll down to see everything before deciding something isn't available.
 * When using your computer function calls, they take a while to run and send back to you.  Where possible/feasible, try to chain multiple of these calls all into one function calls request.
@@ -161,7 +161,7 @@ async def sampling_loop(
         tool_result_content: list[BetaToolResultBlockParam] = []
         for content_block in response_params:
             output_callback(content_block)
-            if content_block["type"] == "tool_use":
+            if (content_block["type"] == "tool_use"):
                 result = await tool_collection.run(
                     name=content_block["name"],
                     tool_input=cast(dict[str, Any], content_block["input"]),


### PR DESCRIPTION
Update the default system prompt for the computer use LLM in `computer-use-demo/computer_use_demo/loop.py`.

* Modify the `SYSTEM_PROMPT` variable to include new instructions for using an Ubuntu virtual machine, specific tools, and commands.
* Update instructions for opening Firefox and starting GUI applications using the bash tool.
* Adjust the example for starting GUI applications to use `gnome-terminal` instead of `xterm`.
* Add parentheses around the condition in the `if` statement checking for `tool_use` type in the loop.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/xwang-otterai/anthropic-quickstarts/pull/1?shareId=fa24c9e2-6bd0-4d73-9ede-4038061ee18e).